### PR TITLE
Updated plugin date to match DokuWiki repo

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   groupmanager
 author Harald Ronge
 email  harald@turtur.nl
-date   2010-11-28
+date   2013-05-27
 name   groupmanager plugin
 desc   Embeddable group manager
 url    http://www.turtur.nl/


### PR DESCRIPTION
With an older date in the plugin files than in the extension repository at https://www.dokuwiki.org/plugins, this plugin will always show as having an update available, even after applying the downloaded update. This fix should mean that the update warning correctly goes away.